### PR TITLE
Prevent hosts using chat

### DIFF
--- a/ensculked-alpha-one/src/main/resources/data/ensculked/powers/ensculked_cosmetic.json
+++ b/ensculked-alpha-one/src/main/resources/data/ensculked/powers/ensculked_cosmetic.json
@@ -31,6 +31,13 @@
   "prevent_label": {
   "type": "apugli:prevent_label_render"
   },
+  "prevent_chat": {
+    "type": "eggolib:prevent_key_use",
+    "keys": [
+      "key.chat",
+      "key.command"
+    ]
+  },
   "gui": {
       "type": "origins:status_bar_texture",
       "texture": "ensculked:textures/gui/icons.png"

--- a/ensculked-alpha-one/src/main/resources/fabric.mod.json
+++ b/ensculked-alpha-one/src/main/resources/fabric.mod.json
@@ -32,6 +32,7 @@
 		"fabricloader": ">=0.16.9",
 		"minecraft": "~1.20.1",
 		"java": ">=17",
+		"eggolib": "^1.9.0",
 		"fabric-api": "*"
 	},
 	"suggests": {


### PR DESCRIPTION
This commit uses Eggolib to prevent hosts sending messages or commands
in chat, and adds an eggolib dependency.
